### PR TITLE
Fix workflow-complete jobs for use by status check jobs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -29,7 +29,7 @@ pull_request_rules:
     - or:
       - and:
         # note this should match the triggering criteria in 'e2e-starter.yml'
-        - check-success=e2e-workflow-complete
+        - check-success~=e2e-workflow-complete
         - or:
           - files~=\.py$
           - files=pyproject.toml
@@ -51,7 +51,7 @@ pull_request_rules:
     - or:
       - and:
         # note this should match the triggering criteria in 'test.yml'
-        - check-success=test-workflow-complete
+        - check-success~=test-workflow-complete
         - or:
           - files~=\.py$
           - files=pyproject.toml
@@ -71,7 +71,7 @@ pull_request_rules:
     - or:
       - and:
         # note this should match the triggering criteria in 'lint.yml'
-        - check-success=lint-workflow-complete
+        - check-success~=lint-workflow-complete
         - or:
           - files~=\.py$
           - files=pyproject.toml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-name: Lint, Format, and MyPy
+name: Lint
 
 on:
   push:
@@ -41,7 +41,8 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    name: "${{ matrix.lint.name }}"
+    # Start name with 'lint:' for lint-workflow-complete job_ids
+    name: "lint: ${{ matrix.lint.name }}"
     strategy:
       fail-fast: false
       matrix:
@@ -103,8 +104,9 @@ jobs:
           python -m pip cache remove llama_cpp_python
 
   lint-workflow-complete:
-    needs: ["lint"]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Lint Workflow Complete
-        run: echo "Lint Workflow Complete"
+    permissions:
+      checks: read
+    uses: ./.github/workflows/status-checks.yml
+    with:
+      job_ids: >- # Space-separated job ids to wait on for status checks
+        lint:

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -47,14 +47,13 @@ jobs:
       - name: "Set status check variables"
         id: set_variables
         run: |
-          jq -nr '[$ARGS.positional[] | split("\\s"; null) | map(select(. != ""))] | flatten | join("|") | ("match_pattern=^(" + . + ")$")' --args "${{ inputs.job_ids }}" >> "$GITHUB_OUTPUT"
+          jq -nr '[$ARGS.positional[] | split("\\s"; null) | map(select(. != ""))] | flatten | join("|") | ("match_pattern=(" + . + ")")' --args "${{ inputs.job_ids }}" >> "$GITHUB_OUTPUT"
 
       - name: "Wait for status checks"
         uses: poseidon/wait-for-status-checks@6988432d64ad3f9c2608db4ca16fded1b7d36ead # v0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           match_pattern: ${{ steps.set_variables.outputs.match_pattern }}
-          ignore_pattern: '/ ${{ github.job }}' # use pattern to ignore this nested job
           delay: ${{ inputs.delay }}
           interval: ${{ inputs.interval }}
           timeout: ${{ inputs.timeout }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ permissions:
   contents: read
 
 jobs:
-  test-ready:
+  test-workflow-ready:
     permissions:
       checks: read
     uses: ./.github/workflows/status-checks.yml
@@ -52,8 +52,9 @@ jobs:
         lint-workflow-complete
 
   test:
-    name: "${{ matrix.python }} on ${{ matrix.platform }}"
-    needs: ["test-ready"]
+    # Start name with 'test:' for test-workflow-complete job_ids
+    name: "test: ${{ matrix.python }} on ${{ matrix.platform }}"
+    needs: ["test-workflow-ready"]
     runs-on: "${{ matrix.platform }}"
     strategy:
       matrix:
@@ -158,7 +159,7 @@ jobs:
           pip cache remove llama_cpp_python
 
   docs:
-    needs: ["test-ready"]
+    needs: ["test-workflow-ready"]
     runs-on: ubuntu-latest
     steps:
       - name: "Harden Runner"
@@ -224,8 +225,11 @@ jobs:
           pip cache remove llama_cpp_python
 
   test-workflow-complete:
-    needs: ["test", "docs"]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Test Workflow Complete
-        run: echo "Test Workflow Complete"
+    permissions:
+      checks: read
+    uses: ./.github/workflows/status-checks.yml
+    with:
+      job_ids: >- # Space-separated job ids to wait on for status checks
+        test-workflow-ready
+        test:
+        docs

--- a/src/instructlab/model/full_train.py
+++ b/src/instructlab/model/full_train.py
@@ -71,7 +71,6 @@ def train(train_args, device):
             effective_batch_size=train_args.effective_batch_size,
             max_batch_len_per_gpu=train_args.max_batch_len,
             is_padding=train_args.is_padding_free,
-            pad_id=tokenizer.pad_token_id,
             dataset=dataset,
             seed=47,
         )


### PR DESCRIPTION
The workflow-complete jobs used job.needs which meant their job ids did not show up in the check-runs until they started. This can be some time since lint jobs take ~20min (and test jobs ~40min). Since the workflow-complete job ids do not appear for quite some time, the status checks in other jobs do not see them and properly wait for them to complete. For example, this allowed the test jobs to start while the lint jobs were still executing.

We change from using job.needs to using a status checks workflow to wait for the member jobs to complete. This quickly creates the entry in check-runs for the workflow-complete jobs which then allows other status check jobs to see their job ids and wait upon their completion.
